### PR TITLE
This closes #27, 

### DIFF
--- a/packages/components/src/layouts/w-divider/index.tsx
+++ b/packages/components/src/layouts/w-divider/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Divider } from '@material-ui/core';
-import { DividerProps } from '@material-ui/core/divider';
+import { DividerProps } from '@material-ui/core/Divider';
 
 export interface WDividerProps extends DividerProps { }
 

--- a/packages/components/src/layouts/w-drawer/index.tsx
+++ b/packages/components/src/layouts/w-drawer/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Drawer } from '@material-ui/core';
-import { DrawerProps } from '@material-ui/core/drawer';
+import { DrawerProps } from '@material-ui/core/Drawer';
 
 export interface WDrawerProps extends DrawerProps { }
 

--- a/packages/components/src/layouts/w-tabs/index.tsx
+++ b/packages/components/src/layouts/w-tabs/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Tabs } from '@material-ui/core';
-import { TabsProps } from '@material-ui/core/tabs';
+import { TabsProps } from '@material-ui/core/Tabs';
 
 export interface WTabsProps extends TabsProps { }
 

--- a/packages/components/src/layouts/w-tabs/w-tab.tsx
+++ b/packages/components/src/layouts/w-tabs/w-tab.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Tab } from '@material-ui/core';
-import { TabProps } from '@material-ui/core/tab';
+import { TabProps } from '@material-ui/core/Tab';
 
 export interface WTabProps extends TabProps { }
 


### PR DESCRIPTION
"divider", "drawer", "tabs", "tab" changed to "Divider", "Drawer", "Tabs", "Tab" because of linux case sensitivity