### PR TITLE
select item menu portal to body bug fixed

### DIFF
--- a/packages/components/src/inputs/w-select/index.tsx
+++ b/packages/components/src/inputs/w-select/index.tsx
@@ -136,7 +136,7 @@ class WSelectInner extends React.Component<WSelectProps, { focused: boolean }> {
             helperText: this.props.helperText,
             style: this.props.style
           }}          
-          menuPortalTarget={document.body}
+          // menuPortalTarget={document.body}
         />
       </NoSsr>
     );


### PR DESCRIPTION
The selection menu stays fix on the screen when the screen is scrolled due to portalTarget prop to body.